### PR TITLE
Run profiling in top level CMSSW directory instead of src tree

### DIFF
--- a/Gen_tool/Gen.sh
+++ b/Gen_tool/Gen.sh
@@ -26,7 +26,7 @@ if [ "X$RELEASE_FORMAT" == "X" -a  "X$CMSSW_IB" == "X" ]; then
   cd ${CMSSW_v}/src
   eval `scramv1 runtime -sh`  
 else
-  cd $WORKSPACE/${CMSSW_v}/src
+  cd $WORKSPACE/${CMSSW_v}
 fi 
 
 ## --2. "RunThematrix" dry run

--- a/Gen_tool/runall.sh
+++ b/Gen_tool/runall.sh
@@ -12,21 +12,19 @@ else
   export SCRAM_ARCH=slc7_amd64_gcc900
 fi
 
-export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
-echo "$VO_CMS_SW_DIR $SCRAM_ARCH"
-source $VO_CMS_SW_DIR/cmsset_default.sh
-
 if [ "X$PROFILING_WORKFLOW" == "X" ];then
   export PROFILING_WORKFLOW="23434.21"
 fi 
 
 if [ "X$WORKSPACE" != "X" ]; then
-  cd $WORKSPACE/$CMSSW_v/src/$PROFILING_WORKFLOW
+  cd $WORKSPACE/$CMSSW_v/$PROFILING_WORKFLOW
 else
-  cd $CMSSW_v/src/TimeMemory
+  export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
+  echo "$VO_CMS_SW_DIR $SCRAM_ARCH"
+  source $VO_CMS_SW_DIR/cmsset_default.sh
+  cd $CMSSW_v/TimeMemory
+  eval `scramv1 runtime -sh`
 fi
-
-eval `scramv1 runtime -sh`
 
 echo "My loc"
 echo $PWD

--- a/Gen_tool/runall_cpu.sh
+++ b/Gen_tool/runall_cpu.sh
@@ -12,19 +12,18 @@ else
 fi
 echo "Your SCRAM_ARCH $SCRAM_ARCH"
 
-export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
-source $VO_CMS_SW_DIR/cmsset_default.sh
-
 if [ "X$PROFILING_WORKFLOW" == "X" ];then
   export PROFILING_WORKFLOW="23434.21"
 fi 
 
 if [ "X$WORKSPACE" != "X" ]; then
-  cd $WORKSPACE/$CMSSW_v/src/$PROFILING_WORKFLOW
+  cd $WORKSPACE/$CMSSW_v/$PROFILING_WORKFLOW
 else
-  cd $CMSSW_v/src/TimeMemory
+  export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
+  source $VO_CMS_SW_DIR/cmsset_default.sh
+  cd $CMSSW_v/TimeMemory
+  eval `scramv1 runtime -sh`
 fi
-eval `scramv1 runtime -sh`
 
 echo "My loc"
 echo $PWD

--- a/Gen_tool/runall_mem.sh
+++ b/Gen_tool/runall_mem.sh
@@ -7,19 +7,19 @@ else
   export SCRAM_ARCH=slc7_amd64_gcc900
 fi
 echo "Your SCRAM_ARCH $SCRAM_ARCH"
-export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
-source $VO_CMS_SW_DIR/cmsset_default.sh
 
 if [ "X$PROFILING_WORKFLOW" == "X" ];then
   export PROFILING_WORKFLOW="23434.21"
 fi 
 
 if [ "X$WORKSPACE" != "X" ]; then
-  cd $WORKSPACE/$CMSSW_v/src/$PROFILING_WORKFLOW
+  cd $WORKSPACE/$CMSSW_v/$PROFILING_WORKFLOW
 else
-  cd $CMSSW_v/src/TimeMemory
+  export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
+  source $VO_CMS_SW_DIR/cmsset_default.sh
+  cd $CMSSW_v/TimeMemory
+  eval `scramv1 runtime -sh`
 fi
-eval `scramv1 runtime -sh`
 
 echo "My loc"
 echo $PWD


### PR DESCRIPTION
I am trying to split the PR tests so that tests can be run from a CMSSW area on cvmfs. This is done by creating local/CMSSW directory with symlinks for src, lib, bin pointing to cvmfs/CMSSW/src,lib.bin etc. This breaks the profiling scripts which want to create files under CMSSW/src. This change suggests to use CMSSW top level directory instead of src

Also do not set the env when run under jenkins which has already set the cmssw env. Resetting the env again will override few PATH e.g. for PR tests we use our own dasgoclient wrapper instead of one provided on cvmfs.