### PR TITLE
Add protection for step5

### DIFF
--- a/Analyze_tool/Gen.sh
+++ b/Analyze_tool/Gen.sh
@@ -92,6 +92,10 @@ cat << EOF >> analyze.sh
     igprof-analyse --sqlite -v -d -g -r MEM_LIVE igprofMEM_step4.mp |sed -e 's/INSERT INTO files VALUES (\([^,]*\), \"[^$]*/INSERT INTO files VALUES (\1, \"ABCD\");/g' | sqlite3 igprof_MEM_PAT_${1}.sql3
     igprof-analyse --sqlite -v -d -g igprofCPU_step4.gz | sed -e 's/INSERT INTO files VALUES (\([^,]*\), \"[^$]*/INSERT INTO files VALUES (\1, \"ABCD\");/g' | sqlite3 igprof_CPU_PAT_${1}.sql3
 
+## -step5
+    igprof-analyse --sqlite -v -d -g -r MEM_LIVE igprofMEM_step5.mp |sed -e 's/INSERT INTO files VALUES (\([^,]*\), \"[^$]*/INSERT INTO files VALUES (\1, \"ABCD\");/g' | sqlite3 igprof_MEM_PAT_${1}.sql3
+    igprof-analyse --sqlite -v -d -g igprofCPU_step5.gz | sed -e 's/INSERT INTO files VALUES (\([^,]*\), \"[^$]*/INSERT INTO files VALUES (\1, \"ABCD\");/g' | sqlite3 igprof_CPU_PAT_${1}.sql3
+
 
 ## --For ascii-based report
 ## -step1
@@ -109,6 +113,10 @@ cat << EOF >> analyze.sh
 ## -step4
     igprof-analyse  -v -d -g -r MEM_LIVE igprofMEM_step4.mp >& RES_PAT_MEM_${1}.res
     igprof-analyse  -v -d -g igprofCPU_step4.gz >& RES_PAT_CPU_${1}.res
+
+## -step5
+    igprof-analyse  -v -d -g -r MEM_LIVE igprofMEM_step5.mp >& RES_PAT_MEM_${1}.res
+    igprof-analyse  -v -d -g igprofCPU_step5.gz >& RES_PAT_CPU_${1}.res
 
 EOF
 

--- a/Analyze_tool/Gen.sh
+++ b/Analyze_tool/Gen.sh
@@ -93,8 +93,12 @@ cat << EOF >> analyze.sh
     igprof-analyse --sqlite -v -d -g igprofCPU_step4.gz | sed -e 's/INSERT INTO files VALUES (\([^,]*\), \"[^$]*/INSERT INTO files VALUES (\1, \"ABCD\");/g' | sqlite3 igprof_CPU_PAT_${1}.sql3
 
 ## -step5
-    igprof-analyse --sqlite -v -d -g -r MEM_LIVE igprofMEM_step5.mp |sed -e 's/INSERT INTO files VALUES (\([^,]*\), \"[^$]*/INSERT INTO files VALUES (\1, \"ABCD\");/g' | sqlite3 igprof_MEM_PAT_${1}.sql3
-    igprof-analyse --sqlite -v -d -g igprofCPU_step5.gz | sed -e 's/INSERT INTO files VALUES (\([^,]*\), \"[^$]*/INSERT INTO files VALUES (\1, \"ABCD\");/g' | sqlite3 igprof_CPU_PAT_${1}.sql3
+    if [ $(ls -d *step5* | wc -l) -gt 0 ]; then
+        igprof-analyse --sqlite -v -d -g -r MEM_LIVE igprofMEM_step5.mp |sed -e 's/INSERT INTO files VALUES (\([^,]*\), \"[^$]*/INSERT INTO files VALUES (\1, \"ABCD\");/g' | sqlite3 igprof_MEM_PAT_${1}.sql3
+        igprof-analyse --sqlite -v -d -g igprofCPU_step5.gz | sed -e 's/INSERT INTO files VALUES (\([^,]*\), \"[^$]*/INSERT INTO files VALUES (\1, \"ABCD\");/g' | sqlite3 igprof_CPU_PAT_${1}.sql3
+    else
+        echo skipping step5 igprof-analyse  
+    fi
 
 
 ## --For ascii-based report
@@ -115,8 +119,12 @@ cat << EOF >> analyze.sh
     igprof-analyse  -v -d -g igprofCPU_step4.gz >& RES_PAT_CPU_${1}.res
 
 ## -step5
-    igprof-analyse  -v -d -g -r MEM_LIVE igprofMEM_step5.mp >& RES_PAT_MEM_${1}.res
-    igprof-analyse  -v -d -g igprofCPU_step5.gz >& RES_PAT_CPU_${1}.res
+    if [ $(ls -d *step5* | wc -l) -gt 0 ]; then
+        igprof-analyse  -v -d -g -r MEM_LIVE igprofMEM_step5.mp >& RES_PAT_MEM_${1}.res
+        igprof-analyse  -v -d -g igprofCPU_step5.gz >& RES_PAT_CPU_${1}.res
+    else
+        echo skipping step5 igprof-analyse  
+    fi
 
 EOF
 

--- a/Gen_tool/runall.sh
+++ b/Gen_tool/runall.sh
@@ -68,3 +68,7 @@ cmsRun$VDT $WRAPPER $(ls step3*.py)  >& step3$VDT.log
 echo step4 circles-wrapper optional
 cmsRun$VDT $WRAPPER $(ls step4*.py)  >& step4$VDT.log
 
+
+echo step5 circles-wrapper optional
+cmsRun$VDT $WRAPPER $(ls step5*.py)  >& step5$VDT.log
+

--- a/Gen_tool/runall.sh
+++ b/Gen_tool/runall.sh
@@ -68,7 +68,10 @@ cmsRun$VDT $WRAPPER $(ls step3*.py)  >& step3$VDT.log
 echo step4 circles-wrapper optional
 cmsRun$VDT $WRAPPER $(ls step4*.py)  >& step4$VDT.log
 
-
-echo step5 circles-wrapper optional
-cmsRun$VDT $WRAPPER $(ls step5*.py)  >& step5$VDT.log
+if [ $(ls -d step5*.py | wc -l) -gt 0 ]; then 
+    echo step5 circles-wrapper optional
+    cmsRun$VDT $WRAPPER $(ls step5*.py)  >& step5$VDT.log
+else
+    echo skipping step5 circles-wrapper optional    
+fi
 

--- a/Gen_tool/runall_cpu.sh
+++ b/Gen_tool/runall_cpu.sh
@@ -81,9 +81,9 @@ echo generating products sizes files
 if [ "X$WORKSPACE" != "X" ];then
   edmEventSize -v ${WORKSPACE}/step3.root > step3_sizes_${PROFILING_WORKFLOW}.txt
   edmEventSize -v ${WORKSPACE}/step4.root > step4_sizes_${PROFILING_WORKFLOW}.txt
-  if [ $(ls -d step5*.py | wc -l) -eq 0 ]; then edmEventSize -v ${WORKSPACE}/step5.root > step5_sizes_${PROFILING_WORKFLOW}.txt; fi
+  if [ $(ls -d step5*.py | wc -l) -gt 0 ]; then edmEventSize -v ${WORKSPACE}/step5.root > step5_sizes_${PROFILING_WORKFLOW}.txt; fi
 else
   edmEventSize -v step3.root > step3_sizes_${PROFILING_WORKFLOW}.txt
   edmEventSize -v step4.root > step4_sizes_${PROFILING_WORKFLOW}.txt
-  if [ $(ls -d step5*.py | wc -l) -eq 0 ]; then edmEventSize -v step5.root > step5_sizes_${PROFILING_WORKFLOW}.txt; fi;
+  if [ $(ls -d step5*.py | wc -l) -gt 0 ]; then edmEventSize -v step5.root > step5_sizes_${PROFILING_WORKFLOW}.txt; fi;
 fi

--- a/Gen_tool/runall_cpu.sh
+++ b/Gen_tool/runall_cpu.sh
@@ -81,9 +81,9 @@ echo generating products sizes files
 if [ "X$WORKSPACE" != "X" ];then
   edmEventSize -v ${WORKSPACE}/step3.root > step3_sizes_${PROFILING_WORKFLOW}.txt
   edmEventSize -v ${WORKSPACE}/step4.root > step4_sizes_${PROFILING_WORKFLOW}.txt
-  if [ $(ls -d step5*.py | wc -l) -gt 0 ]; then edmEventSize -v ${WORKSPACE}/step5.root > step5_sizes_${PROFILING_WORKFLOW}.txt; fi
+  if [ $(ls -d step5*.py | wc -l) -gt 0 ]; then edmEventSize -v ${WORKSPACE}/step5.root > step5_sizes_${PROFILING_WORKFLOW}.txt; else echo skipping step5; fi
 else
   edmEventSize -v step3.root > step3_sizes_${PROFILING_WORKFLOW}.txt
   edmEventSize -v step4.root > step4_sizes_${PROFILING_WORKFLOW}.txt
-  if [ $(ls -d step5*.py | wc -l) -gt 0 ]; then edmEventSize -v step5.root > step5_sizes_${PROFILING_WORKFLOW}.txt; fi;
+  if [ $(ls -d step5*.py | wc -l) -gt 0 ]; then edmEventSize -v step5.root > step5_sizes_${PROFILING_WORKFLOW}.txt; else echo skipping step5; fi;
 fi

--- a/Gen_tool/runall_cpu.sh
+++ b/Gen_tool/runall_cpu.sh
@@ -70,16 +70,20 @@ igprof -pp -z -o ./igprofCPU_step3.gz -- cmsRun $WRAPPER $(ls step3*.py) >& step
 echo step4  w/igprof -pp
 igprof -pp -z -o ./igprofCPU_step4.gz -- cmsRun $WRAPPER $(ls step4*.py) >& step4_cpu.log
 
-echo step5  w/igprof -pp
-igprof -pp -z -o ./igprofCPU_step5.gz -- cmsRun $WRAPPER $(ls step5*.py) >& step5_cpu.log
+if [ $(ls -d step5*.py | wc -l) -gt 0 ]; then
+    echo step5  w/igprof -pp
+    igprof -pp -z -o ./igprofCPU_step5.gz -- cmsRun $WRAPPER $(ls step5*.py) >& step5_cpu.log
+else
+    echo skipping step5  w/igprof -pp
+fi
 
 echo generating products sizes files
 if [ "X$WORKSPACE" != "X" ];then
   edmEventSize -v ${WORKSPACE}/step3.root > step3_sizes_${PROFILING_WORKFLOW}.txt
   edmEventSize -v ${WORKSPACE}/step4.root > step4_sizes_${PROFILING_WORKFLOW}.txt
-  edmEventSize -v ${WORKSPACE}/step5.root > step5_sizes_${PROFILING_WORKFLOW}.txt
+  if [ $(ls -d step5*.py | wc -l) -eq 0 ]; then edmEventSize -v ${WORKSPACE}/step5.root > step5_sizes_${PROFILING_WORKFLOW}.txt; fi
 else
   edmEventSize -v step3.root > step3_sizes_${PROFILING_WORKFLOW}.txt
   edmEventSize -v step4.root > step4_sizes_${PROFILING_WORKFLOW}.txt
-  edmEventSize -v step5.root > step5_sizes_${PROFILING_WORKFLOW}.txt
+  if [ $(ls -d step5*.py | wc -l) -eq 0 ]; then edmEventSize -v step5.root > step5_sizes_${PROFILING_WORKFLOW}.txt; fi;
 fi

--- a/Gen_tool/runall_cpu.sh
+++ b/Gen_tool/runall_cpu.sh
@@ -70,11 +70,16 @@ igprof -pp -z -o ./igprofCPU_step3.gz -- cmsRun $WRAPPER $(ls step3*.py) >& step
 echo step4  w/igprof -pp
 igprof -pp -z -o ./igprofCPU_step4.gz -- cmsRun $WRAPPER $(ls step4*.py) >& step4_cpu.log
 
+echo step5  w/igprof -pp
+igprof -pp -z -o ./igprofCPU_step5.gz -- cmsRun $WRAPPER $(ls step5*.py) >& step5_cpu.log
+
 echo generating products sizes files
 if [ "X$WORKSPACE" != "X" ];then
   edmEventSize -v ${WORKSPACE}/step3.root > step3_sizes_${PROFILING_WORKFLOW}.txt
   edmEventSize -v ${WORKSPACE}/step4.root > step4_sizes_${PROFILING_WORKFLOW}.txt
+  edmEventSize -v ${WORKSPACE}/step5.root > step5_sizes_${PROFILING_WORKFLOW}.txt
 else
   edmEventSize -v step3.root > step3_sizes_${PROFILING_WORKFLOW}.txt
   edmEventSize -v step4.root > step4_sizes_${PROFILING_WORKFLOW}.txt
+  edmEventSize -v step5.root > step5_sizes_${PROFILING_WORKFLOW}.txt
 fi

--- a/Gen_tool/runall_mem.sh
+++ b/Gen_tool/runall_mem.sh
@@ -63,3 +63,10 @@ igprof -mp -o ./igprofMEM_step3.mp -- cmsRunGlibC $WRAPPER $(ls step3*.py)  >& s
 
 echo step4 w/igprof -mp
 igprof -mp -o ./igprofMEM_step4.mp -- cmsRunGlibC  $WRAPPER $(ls step4*.py)  >& step4_mem.log
+
+if [ $(ls -d step5*.py | wc -l) -gt 0 ]; then
+    echo step5 w/igprof -mp
+    igprof -mp -o ./igprofMEM_step5.mp -- cmsRunGlibC  $WRAPPER $(ls step5*.py)  >& step5_mem.log
+else
+    echo skipping step5 w/igprof -mp
+fi


### PR DESCRIPTION
I've noticed that the recent IB profiling tests are failing for 23434.21, most likely because of https://github.com/cms-cmpwg/profiling/pull/3 (see https://cmssdt.cern.ch/jenkins/job/ib-run-profiling/1988/console).

This PR adds some protections in case the step5 is missing.
I still have to test the code