### PR TITLE
Add step5 in Gen.sh

### DIFF
--- a/Gen_tool/Gen.sh
+++ b/Gen_tool/Gen.sh
@@ -79,14 +79,12 @@ with open('cmdLog','r') as f:
                         cnt+=1
                         if cnt<3:
                                 line=line.replace('--customise=HLTrigger/Timer/FastTimer.customise_timer_service_singlejob', '')
-                        if cnt!=5:
+                        else:
                                 line_list = line.split()
                                 logfile = line_list[-2]
                                 line=' '.join(line_list)
                                 line=line.replace(logfile,"step%s.log"%cnt)
                                 line=line.replace('--customise=Validation/Performance/TimeMemoryInfo.py', '')
-                        else:
-                                 break
 ## --Excute cmsDriver
                         print(line)
                         print(" ")

--- a/Gen_tool/Gen.sh
+++ b/Gen_tool/Gen.sh
@@ -121,7 +121,7 @@ cat << EOF >> profile.sh
     igprof-analyse --sqlite -v -d -g igprofCPU_step4.gz | sed -e 's/INSERT INTO files VALUES (\([^,]*\), \"[^$]*/INSERT INTO files VALUES (\1, \"ABCD\");/g' | sqlite3 igprofCPU_step4.sql3 >& CPUsql_step4.log
 
 ## -step5
-    if [ $(ls -d igprofCPU_step5* | wc -l) -gt 0 ]; then 
+    if [ $(ls -d *step5* | wc -l) -gt 0 ]; then 
         igprof-analyse  -v -d -g igprofCPU_step5.gz >& RES_CPU_step5.txt
     fi
 
@@ -145,7 +145,7 @@ awk -v module=doEvent 'BEGIN { total = 0; } { if(substr(\$0,0,1)=="-"){good = 0;
     igprof-analyse  -v -d -g igprofCPU_step4.gz >& RES_CPU_step4.txt
 
 ## -step5
-    if [ $(ls -d igprofCPU_step5* | wc -l) -gt 0 ]; then 
+    if [ $(ls -d *step5* | wc -l) -gt 0 ]; then 
         igprof-analyse  -v -d -g igprofCPU_step5.gz >& RES_CPU_step5.txt
     fi
 
@@ -172,7 +172,7 @@ cat << EOF >> profile_mem.sh
     igprof-analyse --sqlite -v -d -g -r MEM_LIVE igprofMEM_step4.mp |sed -e 's/INSERT INTO files VALUES (\([^,]*\), \"[^$]*/INSERT INTO files VALUES (\1, \"ABCD\");/g' | sqlite3 igprofMEM_step4.sql3 >& MEMsql_step4.log
     
 ## -step5
-    if [ $(ls -d igprofMEM_step5* | wc -l) -gt 0 ]; then 
+    if [ $(ls -d *step5* | wc -l) -gt 0 ]; then 
         igprof-analyse --sqlite -v -d -g -r MEM_LIVE igprofMEM_step5.mp |sed -e 's/INSERT INTO files VALUES (\([^,]*\), \"[^$]*/INSERT INTO files VALUES (\1, \"ABCD\");/g' | sqlite3 igprofMEM_step5.sql3 >& MEMsql_step5.log
     fi
 
@@ -192,7 +192,7 @@ cat << EOF >> profile_mem.sh
     igprof-analyse  -v -d -g -r MEM_LIVE igprofMEM_step4.mp >& RES_MEM_step4.txt
 
 ## -step5
-    if [ $(ls -d igprofMEM_step5* | wc -l) -gt 0 ]; then 
+    if [ $(ls -d *step5* | wc -l) -gt 0 ]; then 
         igprof-analyse  -v -d -g -r MEM_LIVE igprofMEM_step5.mp >& RES_MEM_step5.txt
     fi
 

--- a/Gen_tool/Gen.sh
+++ b/Gen_tool/Gen.sh
@@ -120,6 +120,11 @@ cat << EOF >> profile.sh
 ## -step4
     igprof-analyse --sqlite -v -d -g igprofCPU_step4.gz | sed -e 's/INSERT INTO files VALUES (\([^,]*\), \"[^$]*/INSERT INTO files VALUES (\1, \"ABCD\");/g' | sqlite3 igprofCPU_step4.sql3 >& CPUsql_step4.log
 
+## -step5
+    if [ $(ls -d igprofCPU_step5* | wc -l) -gt 0 ]; then 
+        igprof-analyse  -v -d -g igprofCPU_step5.gz >& RES_CPU_step5.txt
+    fi
+
 
 ## --For ascii-based report
 
@@ -138,6 +143,11 @@ awk -v module=doEvent 'BEGIN { total = 0; } { if(substr(\$0,0,1)=="-"){good = 0;
 
 ## -step4
     igprof-analyse  -v -d -g igprofCPU_step4.gz >& RES_CPU_step4.txt
+
+## -step5
+    if [ $(ls -d igprofCPU_step5* | wc -l) -gt 0 ]; then 
+        igprof-analyse  -v -d -g igprofCPU_step5.gz >& RES_CPU_step5.txt
+    fi
 
 EOF
 chmod +x profile.sh
@@ -160,6 +170,11 @@ cat << EOF >> profile_mem.sh
 
 ## -step4
     igprof-analyse --sqlite -v -d -g -r MEM_LIVE igprofMEM_step4.mp |sed -e 's/INSERT INTO files VALUES (\([^,]*\), \"[^$]*/INSERT INTO files VALUES (\1, \"ABCD\");/g' | sqlite3 igprofMEM_step4.sql3 >& MEMsql_step4.log
+    
+## -step5
+    if [ $(ls -d igprofMEM_step5* | wc -l) -gt 0 ]; then 
+        igprof-analyse --sqlite -v -d -g -r MEM_LIVE igprofMEM_step5.mp |sed -e 's/INSERT INTO files VALUES (\([^,]*\), \"[^$]*/INSERT INTO files VALUES (\1, \"ABCD\");/g' | sqlite3 igprofMEM_step5.sql3 >& MEMsql_step5.log
+    fi
 
 
 ## --For ascii-based report
@@ -175,6 +190,11 @@ cat << EOF >> profile_mem.sh
 
 ## -step4
     igprof-analyse  -v -d -g -r MEM_LIVE igprofMEM_step4.mp >& RES_MEM_step4.txt
+
+## -step5
+    if [ $(ls -d igprofMEM_step5* | wc -l) -gt 0 ]; then 
+        igprof-analyse  -v -d -g -r MEM_LIVE igprofMEM_step5.mp >& RES_MEM_step5.txt
+    fi
 
 EOF
 

--- a/Gen_tool/runall_mem.sh
+++ b/Gen_tool/runall_mem.sh
@@ -63,3 +63,10 @@ igprof -mp -o ./igprofMEM_step3.mp -- cmsRunGlibC $WRAPPER $(ls step3*.py)  >& s
 
 echo step4 w/igprof -mp
 igprof -mp -o ./igprofMEM_step4.mp -- cmsRunGlibC  $WRAPPER $(ls step4*.py)  >& step4_mem.log
+
+if [ $(ls -d step5*.py | wc -l) -gt 0 ]; then 
+    echo step5 w/igprof -mp
+    igprof -mp -o ./igprofMEM_step5.mp -- cmsRunGlibC  $WRAPPER $(ls step5*.py)  >& step5_mem.log
+else
+    echo skipping step5 w/igprof -mp
+fi


### PR DESCRIPTION
This PR adds step5 in Gen.sh and runall_mem.sh, this will allow to check the memory / CPU of the NanoAOD check in https://cmssdt.cern.ch/SDT/cgi-bin/igprof-navigator/CMSSW_12_0_X_2021-07-09-2300/slc7_amd64_gcc900/profiling//11834.21
I added a protection to avoid that the possible missing step5  creates problems.