### PR TITLE
Remove JobReport.xml output from igprof tests

### DIFF
--- a/Gen_tool/runall_cpu.sh
+++ b/Gen_tool/runall_cpu.sh
@@ -74,7 +74,7 @@ export TF_ENABLE_ONEDNN_OPTS=1
 if [ "X$RUNALLSTEPS" != "X" ]; then
   if [ -f step1_igprof.py ]; then
     echo step1 w/igprof -pp cmsRun
-    igprof -pp -d -t cmsRun -z -o ./igprofCPU_step1.gz -- cmsRun step1_igprof.py -j step1_igprof_cpu_JobReport.xml >& step1_igprof_cpu.log
+    igprof -pp -d -t cmsRun -z -o ./igprofCPU_step1.gz -- cmsRun step1_igprof.py >& step1_igprof_cpu.log
     rename_igprof igprofCPU_step1
   else
     echo missing step1_igprof.py
@@ -82,7 +82,7 @@ if [ "X$RUNALLSTEPS" != "X" ]; then
 
   if [ -f step2_igprof.py ]; then
     echo step2  w/igprof -pp cmsRun
-    igprof -pp -d -t cmsRun -z -o ./igprofCPU_step2.gz -- cmsRun step2_igprof.py -j step2_igprof_cpu_JobReport.xml >& step2_igprof_cpu.log
+    igprof -pp -d -t cmsRun -z -o ./igprofCPU_step2.gz -- cmsRun step2_igprof.py  >& step2_igprof_cpu.log
     rename_igprof igprofCPU_step2
   else
     echo missing step2_igprof.py
@@ -91,7 +91,7 @@ fi
 
 if [ -f step3_igprof.py ]; then
   echo step3  w/igprof -pp cmsRun
-  igprof -pp -d -t cmsRun -z -o ./igprofCPU_step3.gz -- cmsRun step3_igprof.py -j step3_igprof_cpu_JobReport.xml >& step3_igprof_cpu.log
+  igprof -pp -d -t cmsRun -z -o ./igprofCPU_step3.gz -- cmsRun step3_igprof.py >& step3_igprof_cpu.log
   rename_igprof igprofCPU_step3
 else
     echo missing step3_igprof.py
@@ -99,7 +99,7 @@ fi
 
 #if [ -f step4_igprof.py ]; then
 #  echo step4  w/igprof -pp cmsRun
-#  igprof -pp -d -t cmsRun -z -o ./igprofCPU_step4.gz -- cmsRun step4_igprof.py -j step4_igprof_cpu_JobReport.xml >& step4_igprof_cpu.log
+#  igprof -pp -d -t cmsRun -z -o ./igprofCPU_step4.gz -- cmsRun step4_igprof.py >& step4_igprof_cpu.log
 #  rename_igprof igprofCPU_step4
 #else
 #    echo missing step4_igprof.py
@@ -107,7 +107,7 @@ fi
 
 #if [ -f step5_igprof.py ]; then
 #  echo step5  w/igprof -pp cmsRun
-#  igprof -pp -d -t cmsRun -z -o ./igprofCPU_step5.gz -- cmsRun step5_igprof.py -j step5_igprof_cpu_JobReport.xml >& step5_igprof_cpu.log
+#  igprof -pp -d -t cmsRun -z -o ./igprofCPU_step5.gz -- cmsRun step5_igprof.py >& step5_igprof_cpu.log
 #  rename_igprof igprofCPU_step5
 #else
 #    echo no step5 in workflow $PROFILING_WORKFLOW


### PR DESCRIPTION
Same job does not crash without -j JobReport.xml [1]
It seems to be the case in the profileRunner[2]
With -j JobReport.xml   igprof seems to crash[3] with a Seg Fault

[1] https://cmssdt.cern.ch/jenkins/job/release-run-reco-profiling/533/console
https://cmssdt.cern.ch/jenkins/job/release-run-reco-profiling/538/console
[2] https://github.com/cms-sw/cms-bot/blob/5bac572863f680e3d69e22005e437665b5df666f/reco_profiling/profileRunner.py#L335
[3] https://github.com/cms-sw/cms-bot/pull/2282#issuecomment-2245206042
https://github.com/cms-sw/cms-bot/pull/2282#issuecomment-2245209330